### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.gnome.eog.yml
+++ b/org.gnome.eog.yml
@@ -10,8 +10,13 @@ finish-args:
   - --socket=fallback-x11
   # Wayland access
   - --socket=wayland
-  # We want full fs access so we can read the files
-  - --filesystem=host
+  # Read all files in possible directories for media
+  - --filesystem=home:ro
+  - --filesystem=/media:ro
+  - --filesystem=/mnt:ro
+  - --filesystem=/run/media:ro
+  - --filesystem=/var/run/media:ro
+  - --filesystem=/var/mnt:ro
   # Migrate old dconf settings
   - --metadata=X-DConf=migrate-path=/org/gnome/eog/
   # GVFS access


### PR DESCRIPTION
it should not have host access, also I think it doesnt need to write? Otherwise please change to rw

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt