### PR TITLE
Update EOG to 45.3

### DIFF
--- a/org.gnome.eog.yml
+++ b/org.gnome.eog.yml
@@ -1,6 +1,6 @@
 id: org.gnome.eog
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: eog
 rename-appdata-file: eog.appdata.xml
@@ -23,12 +23,14 @@ cleanup:
   - /include
   - /lib/pkgconfig
   - /lib/cmake
-  - /share/pkgconfig
-  - /share/aclocal
+  - /lib/girepository-1.0
+  - /libexec
   - /man
-  - /share/man
-  - /share/gtk-doc
+  - /share/aclocal
   - /share/gir-1.0
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
   - '*.la'
   - '*.a'
 modules:
@@ -210,14 +212,16 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/eog/45/eog-45.2.tar.xz
-        sha256: d94cc39d82c80cee7281b82ace42c8225976ad5d0c3ef995c7e030f6bab2219c
+        url: https://download.gnome.org/sources/eog/45/eog-45.3.tar.xz
+        sha256: 8650f662d4921d83a7904f6bb9ca245baf735f717b47fac5b37f0d90e5e891a8
         x-checker-data:
           type: gnome
           name: eog
           is-important: true
       - type: patch
         path: patches/eog-mime.patch
+      - type: patch
+        path: patches/fix_appdata.patch
 
   - name: eog-plugins
     buildsystem: meson

--- a/org.gnome.eog.yml
+++ b/org.gnome.eog.yml
@@ -106,8 +106,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/aruiz/webp-pixbuf-loader.git
-        tag: 0.2.4
-        commit: a35014104a226265e44fe30fcdb4df9305af3466
+        tag: 0.2.7
+        commit: 52232e4ba282b2fed68e8fcb4b5d45ed0eaa4ed3
         x-checker-data:
           type: json
           url: https://api.github.com/repos/aruiz/webp-pixbuf-loader/releases/latest
@@ -159,8 +159,7 @@ modules:
               type: json
               url: https://api.github.com/repos/strukturag/libde265/releases/latest
               version-query: .tag_name | sub("^v"; "")
-              url-query: .assets | map(select(.name=="libde265-\($version).tar.gz"))
-                | first | .browser_download_url
+              url-query: .assets | map(select(.name=="libde265-\($version).tar.gz")) | first | .browser_download_url
               is-important: true
 
   - name: jpeg-xl
@@ -204,8 +203,7 @@ modules:
   - name: update-pixbuf-loaders # libheif, jpegxl, and webp-pixbuf-loader install modules
     buildsystem: simple
     build-commands:
-      - GDK_PIXBUF_MODULEDIR=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders/ gdk-pixbuf-query-loaders
-        > /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      - GDK_PIXBUF_MODULEDIR=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders/ gdk-pixbuf-query-loaders > /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - gdk-pixbuf-query-loaders >> /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 
   - name: eog

--- a/patches/fix_appdata.patch
+++ b/patches/fix_appdata.patch
@@ -1,0 +1,15 @@
+diff --git a/data/eog.appdata.xml.in b/data/eog.appdata.xml.in
+index 6c3b620..2acba5c 100644
+--- a/data/eog.appdata.xml.in
++++ b/data/eog.appdata.xml.in
+@@ -70,6 +70,7 @@
+     <release version="3.36.1" date="2020-04-09" />
+   </releases>
+   <project_group>GNOME</project_group>
++  <developer_name>The GNOME Project</developer_name>
+   <translation type="gettext">eog</translation>
+   <launchable type="desktop-id">org.gnome.eog.desktop</launchable>
+   <content_rating type="oars-1.1" />
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update EOG to 45.3
- Update runtime to 46
- Fix missing developer name
- Clean some artifact to reduce flatpak size
- Update webp-pixbuf-loader.git to 0.2.7